### PR TITLE
Update README to reflect Marcel Park's Portfolio

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,45 +1,51 @@
 <div align="center">
-<img alt="Portfolio" src="https://github.com/dillionverma/portfolio/assets/16860528/57ffca81-3f0a-4425-b31d-094f61725455" width="90%">
+<img alt="Marcel Park Portfolio" src="./public/me.png" width="150px">
 </div>
 
-# Portfolio [![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Fdillionverma%2Fportfolio)
+# Marcel Park's Portfolio [![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Fcode-guerilla%2Fmarcel-park)
 
-Built with next.js, [shadcn/ui](https://ui.shadcn.com/), and [magic ui](https://magicui.design/), deployed on Vercel.
+Software Engineer specializing in React, Next.js, and TypeScript. Built with Next.js, [shadcn/ui](https://ui.shadcn.com/), and [magic ui](https://magicui.design/), deployed on Vercel.
+
+This is an open-source portfolio template. Feel free to clone it and write your own story!
 
 # Features
 
-- Built using Next.js 14, React, Typescript, Shadcn/UI, TailwindCSS, Framer Motion, Magic UI
+- Built using Next.js 15, React 19, Typescript, Shadcn/UI, TailwindCSS, Framer Motion, Magic UI
 - Responsive for different devices
 - Optimized for Next.js and Vercel
+- Internationalization support
 
 # Getting Started Locally
 
 1. Clone this repository to your local machine:
 
    ```bash
-   git clone https://github.com/dillionverma/portfolio
+   git clone https://github.com/code-guerilla/marcel-park
    ```
 
-2. Move to the cloned directory
+2. Move to the cloned directory:
 
    ```bash
-   cd portfolio
+   cd marcel-park
    ```
 
 3. Install dependencies:
 
    ```bash
-   pnpm install
+   bun install
    ```
 
 4. Start the local Server:
 
    ```bash
-   pnpm dev
+   bun dev
    ```
 
-5. Open the [Config file](./src/data/resume.tsx) and make changes
+5. Open the [Config file](./data/resume.tsx) and make changes
 
 # License
 
-Licensed under the [MIT license](https://github.com/dillionverma/portfolio/blob/main/LICENSE.md).
+Licensed under the [MIT license](https://github.com/code-guerilla/marcel-park/blob/main/LICENSE).
+
+Copyright (c) 2024 Dillion Verma
+Copyright (c) 2026 Marcel Park


### PR DESCRIPTION
The README.md was updated to reflect the new owner of the portfolio, Marcel Park. It now includes his name, skills, and correct setup instructions using Bun. The repository links were updated to his own GitHub repository, and the license section was updated to include both the original and new authors. The file also now explicitly mentions that it can be used as an open-source template.

---
*PR created automatically by Jules for task [9507798107483866747](https://jules.google.com/task/9507798107483866747) started by @code-guerilla*