### PR TITLE
De-emphasize side project 'Park Digital Solutions'

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -208,9 +208,9 @@
   }
 
   .prose :where(table):not(:where([class~="not-prose"]) *) {
-    @apply w-full min-w-full;
-    border-collapse: separate;
     border-spacing: 0;
+    border-collapse: separate;
+    @apply w-full min-w-full;
   }
 
   .prose :where(th):not(:where([class~="not-prose"] *)),
@@ -242,6 +242,6 @@
 
 ::view-transition-old(root),
 ::view-transition-new(root) {
-  animation: none;
   mix-blend-mode: normal;
+  animation: none;
 }

--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -1,13 +1,6 @@
 "use client"
 
-import {
-  Award,
-  Briefcase,
-  Code,
-  HomeIcon,
-  type LucideIcon,
-  Mail,
-} from "lucide-react"
+import { Award, Code, HomeIcon, type LucideIcon, Mail } from "lucide-react"
 import { useTranslations } from "next-intl"
 
 import { Dock, DockIcon } from "@/components/magicui/dock"
@@ -31,11 +24,6 @@ type NavItem = {
 
 const navItems: NavItem[] = [
   { href: "/", icon: HomeIcon, labelKey: "home" },
-  {
-    href: "/park-digital-solutions",
-    icon: Briefcase,
-    labelKey: "parkDigitalSolutions",
-  },
   { href: "/#work", icon: Award, labelKey: "resume" },
   { href: "/#projects", icon: Code, labelKey: "projects" },
   { href: "/#contact", icon: Mail, labelKey: "contact" },

--- a/data/resume.tsx
+++ b/data/resume.tsx
@@ -57,17 +57,6 @@ export const DATA = {
   },
   work: [
     {
-      company: "Park Digital Solutions",
-      translationKey: "parkDigitalSolutions",
-      href: "https://park-digital-solutions.com",
-      location: "Nürnberg",
-      logoUrl: "/park-digital-solutions.png",
-      logoClassName:
-        " dark:bg-foreground w-full object-cover pt-1.5 h-10.5 rounded ",
-      start: "2026",
-      end: "heute",
-    },
-    {
       company: "Robert Bosch GmbH",
       translationKey: "bosch",
       href: "https://www.bosch.de",
@@ -96,6 +85,17 @@ export const DATA = {
       logoUrl: "/stadtwerke-elmshorn.svg",
       start: "2012",
       end: "2016",
+    },
+    {
+      company: "Park Digital Solutions",
+      translationKey: "parkDigitalSolutions",
+      href: "https://park-digital-solutions.com",
+      location: "Nürnberg",
+      logoUrl: "/park-digital-solutions.png",
+      logoClassName:
+        " dark:bg-foreground w-full object-cover pt-1.5 h-10.5 rounded ",
+      start: "2026",
+      end: "heute",
     },
   ],
   education: [


### PR DESCRIPTION
The user wanted to make 'Park Digital Solutions' (a side project) less prominent in their CV/portfolio to avoid the impression that it is their main focus.

Changes:
1.  **Work History Reordering:** In `data/resume.tsx`, I moved the 'Park Digital Solutions' entry to the end of the `work` array. This makes 'Robert Bosch GmbH' the first (and most prominent) work experience entry.
2.  **Navbar Cleanup:** I removed the navigation item for `/park-digital-solutions` from `components/navbar.tsx`.
3.  **Metadata Verification:** Confirmed that `app/[locale]/page.tsx` uses `DATA.work[0]` for JSON-LD, so the SEO metadata now correctly reflects the user's primary employment.
4.  **Verification:** Ran `bun run format`, `bun run lint`, and a Playwright verification script to confirm the UI changes. Took a final screenshot at `/home/jules/verification/final_page.png`.

---
*PR created automatically by Jules for task [531953093489581032](https://jules.google.com/task/531953093489581032) started by @code-guerilla*